### PR TITLE
Topic/cccs jsjm/fix unwind over trampoline

### DIFF
--- a/src/Plugin.cc
+++ b/src/Plugin.cc
@@ -28,15 +28,20 @@ using namespace zeek::plugin::Zeek_PerfSupport;
 #define debug(...) PLUGIN_DBG_LOG(plugin, __VA_ARGS__)
 
 namespace zeek {
+    class RethrownInterpreterException : public InterpreterException {
+    public:
+        RethrownInterpreterException() = default;
+    };
+
     class SuspendedException {
     public:
         SuspendedException() = default;
-        void Store(const zeek::InterpreterException& e) {
+        void Store(const InterpreterException& e) {
             has_exception = true;
         }
         void Throw() const {
             if ( has_exception )
-                throw zeek::InterpreterException();
+                throw RethrownInterpreterException();
         }
 
     private:

--- a/src/Trampoline.S
+++ b/src/Trampoline.S
@@ -2,21 +2,22 @@
 .globl  _Zeek_trampoline_func_start
 
 // Val*
-// _Zeek_trampoline(Stmt* stmt, Frame *frame, StmtFlowType *flow, exec_stmt_func_t* esf) {
-//     return esf(stmt, frame, ft);
+// _Zeek_trampoline(Stmt* stmt, Frame *frame, StmtFlowType *flow, SuspendedException *exc, exec_stmt_func_t* esf) {
+//     return esf(stmt, frame, ft, exc);
 // }
 //
 // RDI: stmt
 // RSI: frame
 // RDX: flow
-// RCX: esf
+// RCX: exc
+// R8 : esf
 //
 _Zeek_trampoline_func_start:
 #ifdef __x86_64__
     endbr64
     pushq   %rbp
     movq    %rsp, %rbp
-    call    *%rcx
+    call    *%r8
     popq    %rbp
     ret
 #endif
@@ -26,8 +27,8 @@ _Zeek_trampoline_func_start:
     stp     x29, x30, [sp, -16]!
     mov     x29, sp
     ldp     x29, x30, [sp], 16
-    ldr     x3, [x3]
-    mov     x16, x3
+    ldr     x4, [x4]
+    mov     x16, x4
     br      x16
 #endif
 

--- a/src/Trampoline.S
+++ b/src/Trampoline.S
@@ -13,6 +13,7 @@
 //
 _Zeek_trampoline_func_start:
 #ifdef __x86_64__
+    endbr64
     pushq   %rbp
     movq    %rsp, %rbp
     call    *%rcx

--- a/src/Trampoline.S
+++ b/src/Trampoline.S
@@ -13,19 +13,21 @@
 //
 _Zeek_trampoline_func_start:
 #ifdef __x86_64__
-    sub    $8, %rsp
+    pushq   %rbp
+    movq    %rsp, %rbp
     call    *%rcx
-    add    $8, %rsp
+    popq    %rbp
     ret
 #endif
 #if defined(__aarch64__) && defined(__AARCH64EL__) && !defined(__ILP32__)
     // ARM64 little endian, 64bit ABI
-    // generate with aarch64-linux-gnu-gcc 12.1
+    // generated with aarch64-linux-gnu-gcc 12.3
     stp     x29, x30, [sp, -16]!
     mov     x29, sp
-    blr     x3
     ldp     x29, x30, [sp], 16
-    ret
+    ldr     x3, [x3]
+    mov     x16, x3
+    br      x16
 #endif
 
 .globl  _Zeek_trampoline_func_end

--- a/testing/tests/unwind.sh
+++ b/testing/tests/unwind.sh
@@ -1,0 +1,12 @@
+# @TEST-EXEC: bash %INPUT
+
+set -x
+
+ZEEKPERFSUPPORT=0 zeek -e 'event zeek_init() { print(1/0); }' &> output_disabled
+result_disabled=$?
+
+ZEEKPERFSUPPORT=1 zeek -e 'event zeek_init() { print(1/0); }' &> output_enabled
+result_enabled=$?
+
+# If the program aborts the return codes are not going to be the same.
+[[ $result_disabled == $result_enabled ]] && cmp output_disabled output_enabled


### PR DESCRIPTION
This PR is a proof of concept of a simple solution to prevent the process from aborting when an exception would attempt to unwind the stack over the trampoline. See the last commit message for details. Note that the contents of this PR would require Zeek to add a friend class declaration to zeek::InterpreterException.

The first three commits are unrelated minor improvements.